### PR TITLE
Downgrade Guava from 14 to 13 to address the uncomfirmed issue #34

### DIFF
--- a/transfuse-core/src/main/java/org/androidtransfuse/analysis/InjectionPointFactory.java
+++ b/transfuse-core/src/main/java/org/androidtransfuse/analysis/InjectionPointFactory.java
@@ -145,7 +145,7 @@ public class InjectionPointFactory {
     public InjectionNode buildInjectionNode(Collection<ASTAnnotation> annotations, ASTType astType, AnalysisContext context) {
 
         ImmutableSet<ASTAnnotation> qualifiers =
-                FluentIterable.from(annotations).filter(qualifierPredicate).toSet();
+                FluentIterable.from(annotations).filter(qualifierPredicate).toImmutableSet();
 
         InjectionSignature injectionSignature = new InjectionSignature(astType, qualifiers);
 

--- a/transfuse-core/src/main/java/org/androidtransfuse/analysis/astAnalyzer/AOPProxyAnalyzer.java
+++ b/transfuse-core/src/main/java/org/androidtransfuse/analysis/astAnalyzer/AOPProxyAnalyzer.java
@@ -57,7 +57,7 @@ public class AOPProxyAnalyzer extends ASTAnalysisAdaptor {
                         public boolean apply(ASTMethod method) {
                             return !ASTAccessModifier.PRIVATE.equals(method.getAccessModifier());
                         }
-                    }).toSet();
+                    }).toImmutableSet();
 
                     addInterceptor(injectionNode, nonPrivateMethods, getInterceptorInjectionNode(annotation, context));
                 }

--- a/transfuse-core/src/main/java/org/androidtransfuse/analysis/astAnalyzer/ScopeAnalysis.java
+++ b/transfuse-core/src/main/java/org/androidtransfuse/analysis/astAnalyzer/ScopeAnalysis.java
@@ -56,7 +56,7 @@ public class ScopeAnalysis extends ASTAnalysisAdaptor {
             }
             else{
                 //annotated type
-                ImmutableSet<ASTAnnotation> scopeAnnotations = FluentIterable.from(concreteType.getAnnotations()).filter(scopePredicate).toSet();
+                ImmutableSet<ASTAnnotation> scopeAnnotations = FluentIterable.from(concreteType.getAnnotations()).filter(scopePredicate).toImmutableSet();
 
                 if(scopeAnnotations.size() > 1){
                     validator.error("Only one scoping may be defined")

--- a/transfuse-core/src/main/java/org/androidtransfuse/analysis/module/ProvidesProcessor.java
+++ b/transfuse-core/src/main/java/org/androidtransfuse/analysis/module/ProvidesProcessor.java
@@ -66,11 +66,11 @@ public class ProvidesProcessor implements MethodProcessor {
 
         ImmutableSet<ASTAnnotation> qualifierAnnotations =
                 FluentIterable.from(astMethod.getAnnotations())
-                        .filter(qualifierPredicate).toSet();
+                        .filter(qualifierPredicate).toImmutableSet();
 
         ImmutableSet<ASTAnnotation> scopeAnnotations =
                 FluentIterable.from(astMethod.getAnnotations())
-                        .filter(scopePredicate).toSet();
+                        .filter(scopePredicate).toImmutableSet();
 
         ASTAnnotation scope = null;
         if(scopeAnnotations.size() > 0){
@@ -87,11 +87,11 @@ public class ProvidesProcessor implements MethodProcessor {
                 FluentIterable.from(annotations)
                         .filter(Predicates.and(
                                 Predicates.not(qualifierPredicate),
-                                Predicates.not(scopePredicate))).toSet();
+                                Predicates.not(scopePredicate))).toImmutableSet();
 
         ImmutableSet<ASTAnnotation> scopeAnnotations =
                 FluentIterable.from(annotations)
-                        .filter(scopePredicate).toSet();
+                        .filter(scopePredicate).toImmutableSet();
 
 
         ASTType providesType = astClassFactory.getType(Provides.class);

--- a/transfuse-core/src/main/java/org/androidtransfuse/gen/componentBuilder/InjectionNodeFactoryImpl.java
+++ b/transfuse-core/src/main/java/org/androidtransfuse/gen/componentBuilder/InjectionNodeFactoryImpl.java
@@ -77,7 +77,7 @@ public class InjectionNodeFactoryImpl implements InjectionNodeFactory {
             ASTType parameterType = parameterTypedExpressionEntry.getKey().getASTType();
             TypedExpression expression = parameterTypedExpressionEntry.getValue();
 
-            ImmutableSet<ASTAnnotation> qualifiers = FluentIterable.from(parameter.getAnnotations()).filter(qualifierPredicate).toSet();
+            ImmutableSet<ASTAnnotation> qualifiers = FluentIterable.from(parameter.getAnnotations()).filter(qualifierPredicate).toImmutableSet();
 
             if(qualifiers.isEmpty()){
                 injectionNodeBuilders.putType(new InjectionSignature(parameterType), buildExpression(expression));

--- a/transfuse-support/pom.xml
+++ b/transfuse-support/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>14.0.1</version>
+            <version>13.0.1</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/transfuse-support/src/main/java/org/androidtransfuse/AnnotationProcessorBase.java
+++ b/transfuse-support/src/main/java/org/androidtransfuse/AnnotationProcessorBase.java
@@ -41,7 +41,7 @@ public abstract class AnnotationProcessorBase extends AbstractProcessor {
         return FluentIterable
                 .from(Arrays.asList(supportedAnnotations))
                 .transform(new ClassToNameTransform())
-                .toSet();
+                .toImmutableSet();
     }
 
     private static class ClassToNameTransform implements Function<Class, String> {

--- a/transfuse-support/src/main/java/org/androidtransfuse/adapter/classes/ASTClassAnnotation.java
+++ b/transfuse-support/src/main/java/org/androidtransfuse/adapter/classes/ASTClassAnnotation.java
@@ -51,7 +51,7 @@ public class ASTClassAnnotation implements ASTAnnotation {
     public ImmutableSet<String> getPropertyNames(){
         return FluentIterable.from(Arrays.asList(annotation.annotationType().getDeclaredMethods()))
                 .transform(new MethodNameExtractor())
-                .toSet();
+                .toImmutableSet();
     }
 
     private static final class MethodNameExtractor implements Function<Method, String> {

--- a/transfuse-support/src/main/java/org/androidtransfuse/adapter/classes/LazyClassParameterBuilder.java
+++ b/transfuse-support/src/main/java/org/androidtransfuse/adapter/classes/LazyClassParameterBuilder.java
@@ -51,7 +51,7 @@ public class LazyClassParameterBuilder implements LazyTypeParameterBuilder, Func
     private ImmutableSet<ASTType> innerBuildGenericParameters() {
         return FluentIterable.from(Arrays.asList(parameterizedType.getActualTypeArguments()))
                 .transform(this)
-                .toSet();
+                .toImmutableSet();
     }
 
     @Override

--- a/transfuse-support/src/main/java/org/androidtransfuse/adapter/element/ASTElementAnnotation.java
+++ b/transfuse-support/src/main/java/org/androidtransfuse/adapter/element/ASTElementAnnotation.java
@@ -53,7 +53,7 @@ public class ASTElementAnnotation implements ASTAnnotation {
     public ImmutableSet<String> getPropertyNames() {
         return FluentIterable.from(annotationMirror.getElementValues().keySet())
                 .transform(new ExtractElementName())
-                .toSet();
+                .toImmutableSet();
     }
 
     public AnnotationMirror getAnnotationMirror() {

--- a/transfuse-support/src/main/java/org/androidtransfuse/adapter/element/ASTElementFactory.java
+++ b/transfuse-support/src/main/java/org/androidtransfuse/adapter/element/ASTElementFactory.java
@@ -95,7 +95,7 @@ public class ASTElementFactory {
 
         ImmutableSet<ASTType> interfaces = FluentIterable.from(typeElement.getInterfaces())
                 .transform(astTypeBuilderVisitor)
-                .toSet();
+                .toImmutableSet();
 
         ImmutableSet.Builder<ASTAnnotation> annotations = ImmutableSet.builder();
 
@@ -188,7 +188,7 @@ public class ASTElementFactory {
     private ImmutableSet<ASTType> buildASTElementTypes(List<? extends TypeMirror> mirrorTypes) {
         return FluentIterable.from(mirrorTypes)
                 .transform(astTypeBuilderVisitor)
-                .toSet();
+                .toImmutableSet();
     }
 
     /**

--- a/transfuse-support/src/main/java/org/androidtransfuse/adapter/element/LazyElementParameterBuilder.java
+++ b/transfuse-support/src/main/java/org/androidtransfuse/adapter/element/LazyElementParameterBuilder.java
@@ -49,6 +49,6 @@ public class LazyElementParameterBuilder implements LazyTypeParameterBuilder {
     public ImmutableSet<ASTType> innerBuildGenericParameters() {
         return FluentIterable.from(declaredType.getTypeArguments())
                 .transform(astTypeBuilderVisitor)
-                .toSet();
+                .toImmutableSet();
     }
 }


### PR DESCRIPTION
Refer to https://github.com/johncarl81/transfuse/issues/34

All the changes are replacing FluentIterable.toSet() to .toImmutableSet(). All the changes except one should be correct as the return type is an ImmutableSet anyway, and the exception case is at AnnotationProcessorBase.java that the return type is a plain Set that my change make the return Set immutable. ~~This doesn't cause any error in my app, however.~~ (The tested version used Sets.newHashSet() instead)

For review:

```
public Set<String> getSupportedAnnotationTypes() {
        Class<? extends Annotation>[] supportedAnnotations = getClass().getAnnotation(SupportedAnnotations.class).value();

        return FluentIterable
                .from(Arrays.asList(supportedAnnotations))
                .transform(new ClassToNameTransform())
                .toImmutableSet();//changed from .toSet()
    }
```
