### PR TITLE
Added 'androidManifestFile' annotation processor option

### DIFF
--- a/transfuse/src/main/java/org/androidtransfuse/TransfuseAnnotationProcessor.java
+++ b/transfuse/src/main/java/org/androidtransfuse/TransfuseAnnotationProcessor.java
@@ -115,7 +115,7 @@ public class TransfuseAnnotationProcessor extends AnnotationProcessorBase {
         long start = System.currentTimeMillis();
 
         //setup transfuse processor with manifest and R classes
-        File manifestFile = manifestLocator.findManifest(processingEnv);
+        File manifestFile = manifestLocator.findManifest();
         Manifest manifest = manifestParser.readManifest(manifestFile);
 
         RResourceComposite r = new RResourceComposite(
@@ -192,10 +192,6 @@ public class TransfuseAnnotationProcessor extends AnnotationProcessorBase {
 
     @Override
     public Set<String> getSupportedOptions() {
-        TreeSet<String> set = new TreeSet<String>();
-
-        set.add(ManifestLocator.OPTION_ANDROID_MANIFEST_FILE);
-
-        return set;
+        return Collections.singleton(ManifestLocator.ANDROID_MANIFEST_FILE_OPTION);
     }
 }

--- a/transfuse/src/main/java/org/androidtransfuse/config/TransfuseAndroidModule.java
+++ b/transfuse/src/main/java/org/androidtransfuse/config/TransfuseAndroidModule.java
@@ -85,6 +85,7 @@ public class TransfuseAndroidModule {
     public static final String SCOPES_UTIL_TRANSACTION_WORKER = "scopesUtilTransactionWorker";
     public static final String ORIGINAL_MANIFEST = "originalManifest";
     public static final String MANIFEST_FILE = "manifestFile";
+    public static final String PROCESSING_ENVIRONMENT_OPTIONS = "processingEnvironmentOptions";
 
     @Provides
     @CodeGenerationScope
@@ -114,6 +115,13 @@ public class TransfuseAndroidModule {
     @Singleton
     public Filer getFiler(ProcessingEnvironment processingEnvironment){
         return new SynchronizedFiler(processingEnvironment.getFiler());
+    }
+
+    @Provides
+    @Singleton
+    @Named(PROCESSING_ENVIRONMENT_OPTIONS)
+    public Map<String,String> getOptions(ProcessingEnvironment processingEnvironment){
+        return processingEnvironment.getOptions();
     }
 
     @Provides

--- a/transfuse/src/main/java/org/androidtransfuse/util/ManifestLocator.java
+++ b/transfuse/src/main/java/org/androidtransfuse/util/ManifestLocator.java
@@ -16,15 +16,18 @@
 package org.androidtransfuse.util;
 
 import org.androidtransfuse.TransfuseAnalysisException;
+import org.androidtransfuse.config.TransfuseAndroidModule;
 
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.tools.JavaFileObject;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 
 /**
  * Copied respectfully from the AndroidAnnotations project:
@@ -49,57 +52,39 @@ import java.net.URISyntaxException;
  * @author John Ericksen
  */
 public class ManifestLocator {
-	public static final String OPTION_ANDROID_MANIFEST_FILE = "androidManifestFile";
+	public static final String ANDROID_MANIFEST_FILE_OPTION = "androidManifestFile";
 
     private static final int MAX_PARENTS_FROM_SOURCE_FOLDER = 10;
 
+    private final Map<String,String> options;
     private final Filer filer;
     private final Logger logger;
 
     @Inject
-    public ManifestLocator(Filer filer, Logger logger) {
+    public ManifestLocator(Filer filer, Logger logger, @Named(TransfuseAndroidModule.PROCESSING_ENVIRONMENT_OPTIONS) Map<String,String> options) {
         this.filer = filer;
         this.logger = logger;
-    }
-
-    public File findManifest(ProcessingEnvironment processingEnv) {
-        String androidManifestFilePath = processingEnv.getOptions().get(OPTION_ANDROID_MANIFEST_FILE);
-
-        File androidManifestFile = null;
-
-        if (androidManifestFilePath != null) {
-            if (androidManifestFilePath.startsWith("file:")) {
-                if (!androidManifestFilePath.startsWith("file://")) {
-                    androidManifestFilePath = "file://" + androidManifestFilePath.substring("file:".length());
-                }
-            } else {
-                androidManifestFilePath = "file://" + androidManifestFilePath;
-            }
-
-            try {
-                URI cleanURI = new URI(androidManifestFilePath);
-
-                File file = new File(cleanURI);
-
-                if (file.exists()) {
-                    androidManifestFile = file;
-                    logger.info("AndroidManifest.xml file found: " + androidManifestFile.toString());
-                }
-            } catch (URISyntaxException e) {
-                logger.error("URISyntaxException while trying to load manifest", e);
-                throw new TransfuseAnalysisException("URISyntaxException while trying to load manifest", e);
-            }
-        } else {
-            // Backwards compatibility
-            androidManifestFile = findManifest();
-        }
-
-        return androidManifestFile;
+        this.options = options;
     }
 
     public File findManifest() {
+        String androidManifestFilePath = options.get(ANDROID_MANIFEST_FILE_OPTION);
+
+        File androidManifestFile = null;
+
         try {
-            return findManifestFileThrowing();
+            if (androidManifestFilePath != null) {
+                androidManifestFile = new File(androidManifestFilePath);
+
+                if (!androidManifestFile.exists()) {
+                    throw new IllegalStateException("Could not find the AndroidManifest.xml file specified by option " + ANDROID_MANIFEST_FILE_OPTION + " [" + androidManifestFilePath + "]");
+                } else {
+                    logger.info("AndroidManifest.xml file found: " + androidManifestFile.toString());
+                }
+            } else {
+                // Backwards compatibility
+                androidManifestFile = findManifestFileThrowing();
+            }
         } catch (URISyntaxException e) {
             logger.error("URISyntaxException while trying to load manifest", e);
             throw new TransfuseAnalysisException("URISyntaxException while trying to load manifest", e);
@@ -107,7 +92,10 @@ public class ManifestLocator {
             logger.error("IOException while trying to load manifest", e);
             throw new TransfuseAnalysisException("IOException while trying to load manifest", e);
         }
+
+        return androidManifestFile;
     }
+
 
     /**
      * We use a dirty trick to find the AndroidManifest.xml file, since it's not


### PR DESCRIPTION
To be able to support multiple flavors of an app in Android Studio with Gradle the manifest will almost always be unique per flavor. However the current version of the Transfuse annotation processor will try to find the AndroidManifest.xml automatically. But to be able to find it, the manifest file must be in the root folder. This means (but correct me if I'am wrong) that the manifest is shared across all flavors.

I wanted to use the options provided by the android-apt Gradle plugin to pass the location of the manifest file to the Transfuse annotation processor using the following snippet from the build.gradle file:

```
apt {
    arguments {
        androidManifestFile variant.processResources.manifestFile
    }
```

Is this a viable solution for Transfuse?

Credits for the AndroidAnnotations project which provides a similar solution.
