### PR TITLE
Remove superCall() from onBackPressed callback

### DIFF
--- a/transfuse-api/src/main/java/org/androidtransfuse/annotations/OnResumeFragments.java
+++ b/transfuse-api/src/main/java/org/androidtransfuse/annotations/OnResumeFragments.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2011-2015 John Ericksen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.androidtransfuse.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Activity and Fragment `onResumeFragments()` Lifecycle Event callback method annotation.  Registers the annotated method
+ * to be called during the `onResumeFragments()` Lifecycle Phase.
+ *
+ * @author Paul Tsupikoff
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@EventListener
+public @interface OnResumeFragments {}

--- a/transfuse/src/main/java/org/androidtransfuse/plugins/ActivityPlugin.java
+++ b/transfuse/src/main/java/org/androidtransfuse/plugins/ActivityPlugin.java
@@ -49,7 +49,7 @@ public class ActivityPlugin implements TransfusePlugin{
         repository.component(Activity.class).method("onResumeFragments").event(OnResumeFragments.class).superCall();
         repository.component(Activity.class).method("onStart").event(OnStart.class).superCall();
         repository.component(Activity.class).method("onStop").event(OnStop.class).superCall();
-        repository.component(Activity.class).method("onBackPressed").event(OnBackPressed.class).superCall();
+        repository.component(Activity.class).method("onBackPressed").event(OnBackPressed.class);
         repository.component(Activity.class).method("onPostCreate", AndroidLiterals.BUNDLE).event(OnPostCreate.class).superCall();
         repository.component(Activity.class).method("onActivityResult", ASTPrimitiveType.INT, ASTPrimitiveType.INT, AndroidLiterals.INTENT).event(OnActivityResult.class);
         repository.component(Activity.class).method("onConfigurationChanged", AndroidLiterals.CONTENT_CONFIGURATION).event(OnConfigurationChanged.class).superCall();        

--- a/transfuse/src/main/java/org/androidtransfuse/plugins/ActivityPlugin.java
+++ b/transfuse/src/main/java/org/androidtransfuse/plugins/ActivityPlugin.java
@@ -46,6 +46,7 @@ public class ActivityPlugin implements TransfusePlugin{
         repository.component(Activity.class).method("onPause").event(OnPause.class).superCall();
         repository.component(Activity.class).method("onRestart").event(OnRestart.class).superCall();
         repository.component(Activity.class).method("onResume").event(OnResume.class).superCall();
+        repository.component(Activity.class).method("onResumeFragments").event(OnResumeFragments.class).superCall();
         repository.component(Activity.class).method("onStart").event(OnStart.class).superCall();
         repository.component(Activity.class).method("onStop").event(OnStop.class).superCall();
         repository.component(Activity.class).method("onBackPressed").event(OnBackPressed.class).superCall();


### PR DESCRIPTION
Default implementation of `onBackPressed` method just finishes the activity.
As the usual reason for overriding `onBackPressed` is preventing activity finish, it doesn't seem reasonable to *always* call `super.onBackPressed`.
In case user still wants to finish the activity, he should call injected activity's `finish()` method.