### PR TITLE
Prevent deadlock in EventManager.trigger()

### DIFF
--- a/transfuse-api/src/main/java/org/androidtransfuse/event/EventManager.java
+++ b/transfuse-api/src/main/java/org/androidtransfuse/event/EventManager.java
@@ -148,12 +148,12 @@ public class EventManager {
                     }
                 }
             }
-
-            triggerQueue();
         }
         finally{
             observersLock.readLock().unlock();
         }
+        
+        triggerQueue();
     }
 
     private void triggerQueue(){


### PR DESCRIPTION
If a new event observer is registered during event execution, a deadlock occurs due to locked `observersLock`.