### PR TITLE
Same thread processing pool

### DIFF
--- a/transfuse-support/src/main/java/org/androidtransfuse/transaction/TransactionProcessorPool.java
+++ b/transfuse-support/src/main/java/org/androidtransfuse/transaction/TransactionProcessorPool.java
@@ -16,13 +16,13 @@
 package org.androidtransfuse.transaction;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.MoreExecutors;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -53,7 +53,7 @@ public class TransactionProcessorPool<V, R> implements TransactionProcessor<V, R
      */
     public void execute() {
 
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        ExecutorService executorService = MoreExecutors.sameThreadExecutor();
 
         for (Transaction<V, R> transaction : transactions) {
             if (!transaction.isComplete()) {


### PR DESCRIPTION
Moved to use a single thread (original incoming thread) for processing.  This cleared up issues dealing with Eclipse.  See https://github.com/johncarl81/parceler/issues/30