### PR TITLE
demo swallowed compile error

### DIFF
--- a/examples/gradle/testlibrary/src/main/java/com/example/john/testlibrary/LibraryActivity.java
+++ b/examples/gradle/testlibrary/src/main/java/com/example/john/testlibrary/LibraryActivity.java
@@ -21,12 +21,19 @@ import org.androidtransfuse.annotations.Activity;
 import org.androidtransfuse.annotations.Layout;
 import org.androidtransfuse.annotations.OnCreate;
 import org.rbridge.Bridge;
+import javax.inject.Inject;
 
 @Bridge(R.class)
 @Activity(type = AppCompatActivity.class)
 @Layout(RBridge.layout.activity_library)
 public class LibraryActivity {
+    Thingy thingy;
+
+    @Inject
+    public LibraryActivity(Thingy thingy) {
+        this.thingy = thingy;
+    }
 
     @OnCreate
-    public void create(){}
+    public void create() { }
 }

--- a/examples/gradle/testlibrary/src/main/java/com/example/john/testlibrary/Thingy.java
+++ b/examples/gradle/testlibrary/src/main/java/com/example/john/testlibrary/Thingy.java
@@ -1,0 +1,6 @@
+import javax.inject.Singleton;
+
+@Singleton
+public class Thingy {
+    public final String iBreakStuff;
+}


### PR DESCRIPTION
In this commit I have a class `Thingy` that does not compile (unassigned final variable) but the only error output is related to the component I am attempting to inject it in. If the compile error is deep in the object graph this can be a difficult problem to track down.

`./gradlew clean build`

```
.... 
Note: RBridge: Annotation procesing started, round 1
Note: RBridge: Found 0 classes annotated by @Bridge
Note: RBridge: Took 0ms to process
/Users/dan/dev/projects/zumper/transfuse/examples/gradle/testlibrary/src/main/java/com/example/john/testlibrary/LibraryActivity.java:30: error: cannot find symbol
    Thingy thingy;
    ^
  symbol:   class Thingy
  location: class LibraryActivity
/Users/dan/dev/projects/zumper/transfuse/examples/gradle/testlibrary/src/main/java/com/example/john/testlibrary/LibraryActivity.java:33: error: cannot find symbol
    public LibraryActivity(Thingy thingy) {
                           ^
  symbol:   class Thingy
  location: class LibraryActivity
Note: RBridge: Annotation procesing started, round 2
Note: RBridge: Found 0 classes annotated by @Bridge
Note: RBridge: Took 0ms to process
error: Transfuse: Code generation did not complete successfully.  For more details add the compiler argument -AtransfuseStacktrace
3 errors
:testlibrary:compileDebugJavaWithJavac FAILED
...
```